### PR TITLE
Cleanup/fixes

### DIFF
--- a/flopy4/array.py
+++ b/flopy4/array.py
@@ -228,9 +228,6 @@ class MFArray(MFParam, NumPyArrayMixin):
         self._how = how
         self._factor = factor
 
-    def __get__(self, obj, type=None):
-        return self if self.value is None else self.value
-
     def __getitem__(self, item):
         return self.raw[item]
 

--- a/flopy4/array.py
+++ b/flopy4/array.py
@@ -290,8 +290,15 @@ class MFArray(MFParam, NumPyArrayMixin):
             return self._value.reshape(self._shape) * self.factor
 
     @value.setter
-    def value(self, value: np.ndarray):
-        assert value.shape == self.shape
+    def value(self, value: Optional[np.ndarray]):
+        if value is None:
+            return
+
+        if value.shape != self.shape:
+            raise ValueError(
+                f"Expected array with shape {self.shape},"
+                f"got shape {value.shape}"
+            )
         self._value = value
 
     @property

--- a/flopy4/compound.py
+++ b/flopy4/compound.py
@@ -1,13 +1,26 @@
 from abc import abstractmethod
 from dataclasses import asdict
 from io import StringIO
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Iterator, Optional
 
 from flopy4.param import MFParam, MFParams, MFReader
 from flopy4.scalar import MFScalar
 from flopy4.utils import strip
 
 PAD = "  "
+
+
+def get_keystrings(
+    params: Iterable[MFParam], name=None
+) -> Iterator["MFKeystring"]:
+    """
+    Filter keystring parameters from the given iterable,
+    optionally matching the given component parameter name.
+    """
+    for param in params.values():
+        if isinstance(param, MFKeystring):
+            if name is None or name in param:
+                yield param
 
 
 class MFCompound(MFParam, MFParams):
@@ -98,7 +111,7 @@ class MFRecord(MFCompound):
         default_value=None,
     ):
         super().__init__(
-            params,
+            params=params,
             block=block,
             name=name,
             type=type,
@@ -178,7 +191,7 @@ class MFKeystring(MFCompound):
         default_value=None,
     ):
         super().__init__(
-            params,
+            params=params,
             block=block,
             name=name,
             type=type,

--- a/flopy4/compound.py
+++ b/flopy4/compound.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from collections.abc import Mapping
 from dataclasses import asdict
 from io import StringIO
 from typing import Any, Dict
@@ -54,16 +53,13 @@ class MFCompound(MFParam, MFParams):
             default_value,
         )
 
-    def __get__(self, obj, type=None):
-        return self
-
     @property
     def params(self) -> MFParams:
         """Component parameters."""
         return MFParams(self.data)
 
     @property
-    def value(self) -> Mapping[str, Any]:
+    def value(self) -> Dict[str, Any]:
         """Get component names/values."""
         return {
             k: s.value for k, s in self.data.items() if s.value is not None
@@ -119,6 +115,7 @@ class MFRecord(MFCompound):
 
     @classmethod
     def load(cls, f, params, **kwargs) -> "MFRecord":
+        """Load a record with the given component parameters from a file."""
         line = strip(f.readline()).lower()
 
         if not any(line):
@@ -131,8 +128,9 @@ class MFRecord(MFCompound):
 
     @staticmethod
     def parse(line, params, **kwargs) -> Dict[str, MFScalar]:
-        loaded = dict()
+        """Parse a record with the given component parameters from a string."""
 
+        loaded = dict()
         for param_name, param in params.items():
             split = line.split()
             stype = type(param)

--- a/flopy4/compound.py
+++ b/flopy4/compound.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from dataclasses import asdict
 from io import StringIO
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from flopy4.param import MFParam, MFParams, MFReader
 from flopy4.scalar import MFScalar
@@ -66,8 +66,12 @@ class MFCompound(MFParam, MFParams):
         }
 
     @value.setter
-    def value(self, value):
-        """Set component names/values by keyword arguments."""
+    def value(self, value: Optional[Dict[str, Any]]):
+        """Set component names/values."""
+
+        if value is None:
+            return
+
         for key, val in value.items():
             self.data[key].value = val
 

--- a/flopy4/package.py
+++ b/flopy4/package.py
@@ -14,7 +14,7 @@ def get_block(pkg_name, block_name, params):
         (MFBlock,),
         params.copy(),
     )
-    return cls(params=params, name=block_name)
+    return cls(name=block_name)
 
 
 class MFPackageMeta(type):

--- a/flopy4/package.py
+++ b/flopy4/package.py
@@ -95,7 +95,7 @@ class MFPackage(MFBlocks, metaclass=MFPackageMappingMeta):
         # shortcut to parameter value for instance attribute.
         # the class attribute is the parameter specification.
         if name in self_type.params:
-            return self._param_values()[name]
+            return self._get_param_values()[name]
 
         # add .blocks attribute as an alias for .value, this
         # overrides the class attribute with the block spec.
@@ -104,7 +104,7 @@ class MFPackage(MFBlocks, metaclass=MFPackageMappingMeta):
         if name == "blocks":
             return self.value
         elif name == "params":
-            return self._param_values()
+            return self._get_param_values()
 
         return super().__getattribute__(name)
 
@@ -113,7 +113,7 @@ class MFPackage(MFBlocks, metaclass=MFPackageMappingMeta):
         self.write(buffer)
         return buffer.getvalue()
 
-    def _param_values(self):
+    def _get_param_values(self):
         # todo cache
         return MFParams(
             {

--- a/flopy4/param.py
+++ b/flopy4/param.py
@@ -185,6 +185,11 @@ class MFParams(UserDict):
     def __repr__(self):
         return pformat(self.data)
 
+    @property
+    def value(self):
+        """Get a dictionary of parameter values."""
+        return {k: v.value for k, v in self.items()}
+
     def write(self, f, **kwargs):
         """Write the parameters to file."""
         for param in self.values():

--- a/flopy4/param.py
+++ b/flopy4/param.py
@@ -173,8 +173,8 @@ class MFParam(MFParamSpec):
 
 class MFParams(UserDict):
     """
-    Mapping of parameter names to parameters.
-    Supports dictionary and attribute access.
+    Mapping of parameter names to parameters. Acts like
+    a dictionary and supports named attribute access.
     """
 
     def __init__(self, params=None):

--- a/flopy4/param.py
+++ b/flopy4/param.py
@@ -29,6 +29,8 @@ class MFParamSpec:
     repeating: bool = False
     tagged: bool = True
     reader: MFReader = MFReader.urword
+    # todo change to variadic tuple of str and resolve
+    # actual shape at load time from simulation context
     shape: Optional[Tuple[int]] = None
     default_value: Optional[Any] = None
 
@@ -53,6 +55,7 @@ class MFParamSpec:
         spec = dict()
         members = cls.fields()
         keywords = [f.name for f in members if f.type is bool]
+
         while True:
             line = f.readline()
             if not line or line == "\n":
@@ -68,6 +71,7 @@ class MFParamSpec:
                 spec[key] = literal_eval(val)
             else:
                 spec[key] = val
+
         return cls(**spec)
 
     def with_name(self, name) -> "MFParamSpec":
@@ -183,5 +187,5 @@ class MFParams(UserDict):
 
     def write(self, f, **kwargs):
         """Write the parameters to file."""
-        for param in self.data.values():
+        for param in self.values():
             param.write(f, **kwargs)

--- a/flopy4/scalar.py
+++ b/flopy4/scalar.py
@@ -1,14 +1,16 @@
 from abc import abstractmethod
 from pathlib import Path
+from typing import Generic, Optional, TypeVar, get_args
 
 from flopy4.constants import MFFileInout
 from flopy4.param import MFParam, MFReader
 from flopy4.utils import strip
 
 PAD = "  "
+T = TypeVar("T")
 
 
-class MFScalar(MFParam):
+class MFScalar(MFParam, Generic[T]):
     @abstractmethod
     def __init__(
         self,
@@ -31,7 +33,8 @@ class MFScalar(MFParam):
         default_value=None,
     ):
         self._value = value
-        super().__init__(
+        MFParam.__init__(
+            self,
             block,
             name,
             type,
@@ -50,25 +53,29 @@ class MFScalar(MFParam):
             default_value,
         )
 
+    def __init_subclass__(cls):
+        cls.T = get_args(cls.__orig_bases__[0])[0]
+        super().__init_subclass__()
+
     @property
-    def value(self):
+    def value(self) -> T:
         return self._value
 
     @value.setter
-    def value(self, value):
+    def value(self, value: Optional[T]):
         if value is None:
             return
 
-        tval = type(value)
-        if issubclass(tval, MFScalar):
+        t = type(value)
+        if issubclass(t, MFScalar):
             self._value = value.value
-        elif tval in [bool, int, float, str, Path]:
+        elif t is type(self).T:
             self._value = value
         else:
             raise ValueError(f"Unsupported scalar: {value}")
 
 
-class MFKeyword(MFScalar):
+class MFKeyword(MFScalar[bool]):
     def __init__(
         self,
         value=None,
@@ -132,7 +139,7 @@ class MFKeyword(MFScalar):
             )
 
 
-class MFInteger(MFScalar):
+class MFInteger(MFScalar[int]):
     def __init__(
         self,
         value=None,
@@ -176,6 +183,10 @@ class MFInteger(MFScalar):
     def __len__(self):
         return 2
 
+    @property
+    def vtype(self):
+        return int
+
     @classmethod
     def load(cls, f, **kwargs) -> "MFInteger":
         line = strip(f.readline()).lower()
@@ -196,7 +207,7 @@ class MFInteger(MFScalar):
         )
 
 
-class MFDouble(MFScalar):
+class MFDouble(MFScalar[float]):
     def __init__(
         self,
         value=None,
@@ -260,7 +271,7 @@ class MFDouble(MFScalar):
         )
 
 
-class MFString(MFScalar):
+class MFString(MFScalar[str]):
     def __init__(
         self,
         value=None,
@@ -302,7 +313,7 @@ class MFString(MFScalar):
         )
 
     def __len__(self):
-        return None if self._value is None else len(self._value.split())
+        return 0 if self._value is None else len(self._value.split())
 
     @classmethod
     def load(cls, f, **kwargs) -> "MFString":
@@ -324,7 +335,7 @@ class MFString(MFScalar):
         )
 
 
-class MFFilename(MFScalar):
+class MFFilename(MFScalar[Path]):
     def __init__(
         self,
         inout=MFFileInout.filein,

--- a/flopy4/scalar.py
+++ b/flopy4/scalar.py
@@ -50,16 +50,19 @@ class MFScalar(MFParam):
             default_value,
         )
 
-    def __get__(self, obj, type=None):
-        return self if self.value is None else self.value
-
     @property
     def value(self):
         return self._value
 
     @value.setter
     def value(self, value):
-        self._value = value
+        tvalue = type(value)
+        if issubclass(tvalue, MFScalar):
+            self._value = value.value
+        elif tvalue in [bool, int, float, str, Path]:
+            self._value = value
+        else:
+            raise ValueError(f"Unsupported scalar value: {value}")
 
 
 class MFKeyword(MFScalar):

--- a/flopy4/scalar.py
+++ b/flopy4/scalar.py
@@ -56,13 +56,16 @@ class MFScalar(MFParam):
 
     @value.setter
     def value(self, value):
-        tvalue = type(value)
-        if issubclass(tvalue, MFScalar):
+        if value is None:
+            return
+
+        tval = type(value)
+        if issubclass(tval, MFScalar):
             self._value = value.value
-        elif tvalue in [bool, int, float, str, Path]:
+        elif tval in [bool, int, float, str, Path]:
             self._value = value
         else:
-            raise ValueError(f"Unsupported scalar value: {value}")
+            raise ValueError(f"Unsupported scalar: {value}")
 
 
 class MFKeyword(MFScalar):

--- a/flopy4/utils.py
+++ b/flopy4/utils.py
@@ -22,7 +22,3 @@ def strip(line):
         line = line.split(comment_flag)[0]
     line = line.strip()
     return line.replace(",", " ")
-
-
-class hybridproperty:
-    pass

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import numpy as np
+import pytest
 
 from flopy4.array import MFArray
 from flopy4.block import MFBlock
@@ -164,3 +167,20 @@ def test_load_write_indexed(tmp_path):
         # instance attribute as shortcut to param value
         assert period1.ks == {"first": True}
         assert period2.ks == {"first": True, "frequency": 2}
+
+
+def test_set_value():
+    block = TestBlock(name="test")
+    block.value = {
+        "k": True,
+        "i": 42,
+        "d": 2.0,
+        "s": "hello world",
+    }
+    assert block.k
+
+
+def test_set_value_unrecognized():
+    block = TestBlock(name="test")
+    with pytest.raises(ValueError):
+        block.value = {"p": Path.cwd()}

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -97,14 +97,15 @@ def test_load_write(tmp_path):
         assert isinstance(TestBlock.r.params["ri"], MFInteger)
         assert isinstance(TestBlock.r.params["rd"], MFDouble)
 
-        # check parameter values (via descriptors)
-        assert block.k
-        assert block.i == 1
-        assert block.d == 1.0
-        assert block.s == "value"
-        assert block.f == fpth
+        # check parameter values
+        assert block.k and block.value["k"]
+        assert block.i == block.value["i"] == 1
+        assert block.d == block.value["d"] == 1.0
+        assert block.s == block.value["s"] == "value"
+        assert block.f == block.value["f"] == fpth
         assert np.allclose(block.a, np.array([1.0, 2.0, 3.0]))
-        assert block.r == {"rd": 2.0, "ri": 2, "rk": True}
+        assert np.allclose(block.value["a"], np.array([1.0, 2.0, 3.0]))
+        assert block.r == block.value["r"] == {"rd": 2.0, "ri": 2, "rk": True}
 
     # test block write
     fpth2 = tmp_path / f"{name}2.txt"
@@ -151,6 +152,7 @@ def test_load_write_indexed(tmp_path):
         period1 = IndexedBlock.load(f)
         period2 = IndexedBlock.load(f)
 
+        # todo: go to 0-based indexing
         assert period1.index == 1
         assert period2.index == 2
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -61,7 +61,6 @@ class TestGwfIc(MFPackage):
         optional=False,
         # shape="(nodes)",
         shape=(10),
-        default_value=False,
     )
 
 
@@ -316,20 +315,16 @@ def test_load_gwfic(tmp_path):
     with open(fpth, "r") as f:
         gwfic = TestGwfIc.load(f)
 
-    assert len(TestGwfIc.blocks) == 2
-    assert len(TestGwfIc.params) == 3
-
-    # assert len(gwfic.blocks) == 2
-    # assert len(gwfic.params) == 2  # only two params loaded
+    assert len(TestGwfIc.blocks) == len(gwfic.blocks) == 2
+    assert len(TestGwfIc.params) == len(gwfic.params) == 3
 
     # instance attributes: shortcut access to param values
     assert isinstance(gwfic.export_array_ascii, bool)
-    # todo debug key error: need to set empty/default values in
-    # mfparams (and mfblocks?) ctors for all values not given
-    # assert isinstance(gwfic.export_array_netcdf, MFKeyword)
+    assert isinstance(gwfic.export_array_netcdf, bool)
     assert isinstance(gwfic.strt, np.ndarray)
 
     assert gwfic.export_array_ascii
+    assert not gwfic.export_array_netcdf
     assert np.allclose(gwfic.strt, np.array(strt))
 
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -294,7 +294,7 @@ def test_loadfail_gwfic(tmp_path):
         try:
             TestGwfIc.load(f)
         except ValueError as e:
-            assert "NOT_AN_OPTION" in str(e)
+            assert "not_an_option" in str(e)
 
 
 def test_load_gwfic(tmp_path):

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -319,12 +319,14 @@ def test_load_gwfic(tmp_path):
     assert len(TestGwfIc.blocks) == 2
     assert len(TestGwfIc.params) == 3
 
-    assert len(gwfic.blocks) == 2
-    assert len(gwfic.params) == 2  # only two params loaded
+    # assert len(gwfic.blocks) == 2
+    # assert len(gwfic.params) == 2  # only two params loaded
 
     # instance attributes: shortcut access to param values
     assert isinstance(gwfic.export_array_ascii, bool)
-    assert isinstance(gwfic.export_array_netcdf, MFKeyword)
+    # todo debug key error: need to set empty/default values in
+    # mfparams (and mfblocks?) ctors for all values not given
+    # assert isinstance(gwfic.export_array_netcdf, MFKeyword)
     assert isinstance(gwfic.strt, np.ndarray)
 
     assert gwfic.export_array_ascii


### PR DESCRIPTION
* no descriptor protocol for now, maybe reintroduce later as `__getattributes__` is a bit heavy-handed
* miscellaneous code cleanup and docstring improvements
* add value getters/setters to block/package classes
* add classmethods to coerce params/blocks to spec
* support equality comparisons for param/block/package
* give scalar param subclasses a generic type parameter